### PR TITLE
Do not directly require --protected-locatins, check if the arg is set instead

### DIFF
--- a/bin/keycloak-httpd-client-install
+++ b/bin/keycloak-httpd-client-install
@@ -920,15 +920,19 @@ def main():
 
 
     group.add_argument('--mellon-hostname', action=utils.DeprecatedStoreAction,
+                       dest='client_hostname',
                        help='use --client-hostname')
 
     group.add_argument('--mellon-https-port', action=utils.DeprecatedStoreAction,
+                       dest='client_https_port',
                        help='User --client-https-port')
 
     group.add_argument('--mellon-root', action=utils.DeprecatedStoreAction,
+                       dest='location_root',
                        help='Use --location-root')
 
     group.add_argument('--mellon-entity-id', action=utils.DeprecatedStoreAction,
+                       dest='clientid',
                        help='use --clientid')
 
     # ===== Process command line arguments =====

--- a/bin/keycloak-httpd-client-install
+++ b/bin/keycloak-httpd-client-install
@@ -852,7 +852,6 @@ def main():
                        'defaults to {client_hostname}-{app_name}')
 
     group.add_argument('-l', '--protected-locations', action='append',
-                       required=True,
                        type=arg_type_protected_location, default=[],
                        help='Web location to protect with client. '
                             'May be specified multiple times')
@@ -935,6 +934,9 @@ def main():
     # ===== Process command line arguments =====
 
     options = parser.parse_args()
+
+    if len(options.protected_locations) == 0:
+        parser.error("You must specify -l/--protected-locations")
 
     # ===== Configure Logging =====
 


### PR DESCRIPTION
k-h-c-i deprecated the use of --mellon-protected-locations in favour of
--protected-locatins, but the old name should still work. But, because
--protected-locatins was flagged as required with python's argparse,
just specifying --mellon-protected-locations threw an error.

This patch moves the check to after the flags are evaluated.