### PR TITLE
doc: Fix a typo in --oidc-redirect-uri description

### DIFF
--- a/doc/keycloak-httpd-client-install.8
+++ b/doc/keycloak-httpd-client-install.8
@@ -205,7 +205,7 @@ Common root ancestor for all protected locations
 .B mod_auth_oidc OIDC RP Client Options
 
 .TP
-.BR \-\-oidc\-redirect\--uri " " \fIOIDC_REDIRECT_URI\fR
+.BR \-\-oidc\-redirect\-uri " " \fIOIDC_REDIRECT_URI\fR
 The OIDC redirect_uri. Must be an antecedent (i.e. child) of one of the
 protected locations.
 (default: The first protected location appened with "/redirect_uri")


### PR DESCRIPTION
There were two dashes, should be just one. Reported by Scott Poore.