### PR TITLE
Fix rpm spec file and python2 incompatibility

### DIFF
--- a/keycloak_httpd_client/utils.py
+++ b/keycloak_httpd_client/utils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import argparse
 import base64
 import copy


### PR DESCRIPTION
Importing the print_function helps to use this script on RHEL / CentOS 7 and the modification in spec file is to successfully build rpm without errors regarding keycloak-rest file.